### PR TITLE
Modified e-gfr, uacr, weight-over-time css to display same colors in …

### DIFF
--- a/src/app/e-gfr/e-gfr.component.css
+++ b/src/app/e-gfr/e-gfr.component.css
@@ -24,14 +24,14 @@ tr.mat-row {
   height: 24px !important;
 }
 
-tr.mat-row.resultBorderline{
-  background-color: lightgoldenrodyellow;
+tr.mat-row.resultGood{
+  background-color: rgba(247, 245, 116, 0.3);
 }
 
-tr.mat-row.resultGood{
-  background-color: palegreen;
+tr.mat-row.resultBorderline{
+  background-color: rgba(128, 204, 113, 0.3);
 }
 
 tr.mat-row.resultCritical{
-  background-color: lightpink;
+  background-color: rgba(227, 127, 104, 0.3);
 }

--- a/src/app/uacr/uacr.component.css
+++ b/src/app/uacr/uacr.component.css
@@ -24,14 +24,14 @@ tr.mat-row {
   height: 24px !important;
 }
 
-tr.mat-row.resultBorderline{
-  background-color: lightgoldenrodyellow;
+tr.mat-row.resultGood{
+  background-color: rgba(247, 245, 116, 0.3);
 }
 
-tr.mat-row.resultGood{
-  background-color: palegreen;
+tr.mat-row.resultBorderline{
+  background-color: rgba(128, 204, 113, 0.3);
 }
 
 tr.mat-row.resultCritical{
-  background-color: lightpink;
+  background-color: rgba(227, 127, 104, 0.3);
 }

--- a/src/app/weight-over-time/weight-over-time.component.css
+++ b/src/app/weight-over-time/weight-over-time.component.css
@@ -24,14 +24,14 @@ tr.mat-row {
   height: 24px !important;
 }
 
-tr.mat-row.resultBorderline{
-  background-color: lightgoldenrodyellow;
+tr.mat-row.resultGood{
+  background-color: rgba(247, 245, 116, 0.3);
 }
 
-tr.mat-row.resultGood{
-  background-color: palegreen;
+tr.mat-row.resultBorderline{
+  background-color: rgba(128, 204, 113, 0.3);
 }
 
 tr.mat-row.resultCritical{
-  background-color: lightpink;
+  background-color: rgba(227, 127, 104, 0.3);
 }

--- a/src/utility-functions.ts
+++ b/src/utility-functions.ts
@@ -203,7 +203,7 @@ export function getEgrLineChartAnnotationsObject() {
       {
         drawTime: 'beforeDatasetsDraw',
         type: 'box',
-        id: 'egfr-warning',
+        id: 'egfr-ok',
         xScaleID: 'x-axis-0',
         yScaleID: 'y-axis-0',
         borderWidth: 0,
@@ -214,7 +214,7 @@ export function getEgrLineChartAnnotationsObject() {
       {
         drawTime: 'beforeDatasetsDraw',
         type: 'box',
-        id: 'egfr-ok',
+        id: 'egfr-warning',
         xScaleID: 'x-axis-0',
         yScaleID: 'y-axis-0',
         borderWidth: 0,
@@ -232,7 +232,7 @@ export function getUacrLineChartAnnotationsObject() {
     annotations: [{
       drawTime: 'beforeDatasetsDraw',
       type: 'box',
-      id: 'uacr-ok',
+      id: 'uacr-warning',
       xScaleID: 'x-axis-0',
       yScaleID: 'y-axis-0',
       borderWidth: 0,
@@ -243,7 +243,7 @@ export function getUacrLineChartAnnotationsObject() {
       {
         drawTime: 'beforeDatasetsDraw',
         type: 'box',
-        id: 'uacr-warning',
+        id: 'uacr-ok',
         xScaleID: 'x-axis-0',
         yScaleID: 'y-axis-0',
         borderWidth: 0,
@@ -272,7 +272,7 @@ export function getWotLineChartAnnotationsObject() {
     annotations: [{
       drawTime: 'beforeDatasetsDraw',
       type: 'box',
-      id: 'wot-ok',
+      id: 'wot-warning',
       xScaleID: 'x-axis-0',
       yScaleID: 'y-axis-0',
       borderWidth: 0,
@@ -283,7 +283,7 @@ export function getWotLineChartAnnotationsObject() {
       {
         drawTime: 'beforeDatasetsDraw',
         type: 'box',
-        id: 'wot-warning',
+        id: 'wot-ok',
         xScaleID: 'x-axis-0',
         yScaleID: 'y-axis-0',
         borderWidth: 0,


### PR DESCRIPTION
Modified e-gfr, uacr, weight-over-time css to display same colors in tables as the graphs

![Screen Shot 2020-11-12 at 3 46 52 PM](https://user-images.githubusercontent.com/6099342/99010172-51f16600-24fe-11eb-9583-7f69860cc7fa.png)
