### PR TITLE
Release 1.1.9 - Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ $ docker run -v {Full 'json/data' Directory Path}:/usr/share/nginx/html/assets/j
 - Gave uniform widths to missized tables and charts on the "Health Status" page
 - Some small table padding improvements for more fluid ui
 - Fixed observation calls not adding header or handling errors correctly.  Should fix lab results not loading.
+- Added some loading spinners
 
 2021-06-15
 - Release ("1.1.8")

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ $ docker run -v {Full 'json/data' Directory Path}:/usr/share/nginx/html/assets/j
 #Changelog
 2021-07-19
 - Release ("1.1.9")
-- Gave uniform widths to missized tables and charts on the "Health Status" page
-- Some small table padding improvements for more fluid ui
+- Gave uniform widths to tables and charts on the "Health Status" page to fix some odd sizing
+- Some small table padding improvements for cleaner ui
 - Fixed observation calls not adding header or handling errors correctly.  Should fix lab results not loading.
 - Added some loading spinners
 

--- a/src/app/clinical-test-results/clinical-test-results.component.html
+++ b/src/app/clinical-test-results/clinical-test-results.component.html
@@ -22,7 +22,7 @@
   </tr>
   <tr *ngIf="!dataservice.vitalSignResults || dataservice.vitalSignResults.length === 0">
     <td colspan="3">
-      Loading...
+      <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
     </td>
   </tr>
   <tr *ngFor="let res of dataservice.vitalSignResults">

--- a/src/app/lab-test-result/lab-test-result.component.html
+++ b/src/app/lab-test-result/lab-test-result.component.html
@@ -22,7 +22,7 @@
   </tr>
   <tr *ngIf="!dataservice.labResults || dataservice.labResults.length === 0">
     <td colspan="3">
-      {{loadingText}}
+      <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
     </td>
   </tr>
   <tr *ngFor="let res of dataservice.labResults">


### PR DESCRIPTION
- Release ("1.1.9")
- Gave uniform widths to missized tables and charts on the "Health Status" page
- Some small table padding improvements for more fluid ui
- Fixed observation calls not adding header or handling errors correctly.  Should fix lab results not loading.
- Added some loading spinners