### PR TITLE
Feature/ie11 resizing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ $ docker run -v {Full 'json/data' Directory Path}:/usr/share/nginx/html/assets/j
 - Release ("1.2.0")
 - Attempt to fix IE 11 Table overlap bug on "Health Status" screen (unable to debug IE11 locally)
 - More logging on "DATA" property assignments
+- Better spinner handling
 
 2021-07-19
 - Release ("1.1.9")

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ The file names and types must match exactly.  Also, you must include all json fi
 $ docker run -v {Full 'json/data' Directory Path}:/usr/share/nginx/html/assets/json/data -d -p 80:80 --rm mcccareplan/mccproviderapp
 
 #Changelog
+2021-07-22
+- Release ("1.2.0")
+- Attempt to fix IE 11 Table overlap bug on "Health Status" screen (unable to debug IE11 locally)
+- More logging on "DATA" property assignments
+
 2021-07-19
 - Release ("1.1.9")
 - Gave uniform widths to tables and charts on the "Health Status" page to fix some odd sizing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "providersmartapp",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/clinical-test-results/clinical-test-results.component.html
+++ b/src/app/clinical-test-results/clinical-test-results.component.html
@@ -21,7 +21,7 @@
     </td>
   </tr>
   <tr *ngIf="!dataservice.vitalSignResults || dataservice.vitalSignResults.length === 0">
-    <td colspan="3">
+    <td colspan="3" style="height: 200px;">
       <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
     </td>
   </tr>

--- a/src/app/diagnosis-panel/diagnosis-panel.component.html
+++ b/src/app/diagnosis-panel/diagnosis-panel.component.html
@@ -1,5 +1,14 @@
+<app-active-diagnosis-panel *ngIf="featureToggling.healthAndSocialConcerns.activeDiagnoses && getActiveIsReady()">
+</app-active-diagnosis-panel>
 
-<app-active-diagnosis-panel *ngIf="featureToggling.healthAndSocialConcerns.activeDiagnoses && getActiveIsReady()"></app-active-diagnosis-panel>
-<mat-spinner *ngIf="featureToggling.healthAndSocialConcerns.activeDiagnoses && !getActiveIsReady()" style="margin:0 auto;" mode="indeterminate"></mat-spinner>
-<app-inactive-diagnosis-panel *ngIf="featureToggling.healthAndSocialConcerns.inactiveDiagnoses && getInActiveIsReady()"></app-inactive-diagnosis-panel>
-<mat-spinner  *ngIf="featureToggling.healthAndSocialConcerns.inactiveDiagnoses && !getInActiveIsReady()" style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+<div *ngIf="featureToggling.healthAndSocialConcerns.activeDiagnoses && !getActiveIsReady()" style="height: 200px;">
+    <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+</div>
+
+<app-inactive-diagnosis-panel *ngIf="featureToggling.healthAndSocialConcerns.inactiveDiagnoses && getInActiveIsReady()">
+</app-inactive-diagnosis-panel>
+
+<div *ngIf="featureToggling.healthAndSocialConcerns.inactiveDiagnoses && !getInActiveIsReady()" style="height: 200px;">
+    <mat-spinner style="margin:0 auto;" mode=" indeterminate">
+    </mat-spinner>
+</div>

--- a/src/app/health-and-social-concerns/health-and-social-concerns.component.html
+++ b/src/app/health-and-social-concerns/health-and-social-concerns.component.html
@@ -8,6 +8,8 @@
     </app-social-concern-panel>
   </section>
   <section *ngIf="!getSocialConcernIsReady() && featureToggling.healthAndSocialConcerns.socialConcerns">
-    <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+    <div style="height: 200px;">
+      <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+    </div>
   </section>
 </div>

--- a/src/app/health-status/health-status.component.css
+++ b/src/app/health-status/health-status.component.css
@@ -16,3 +16,23 @@
     padding: 0;
   }
 }
+
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+  @media (min-width: 1450px) {
+    section {
+      width: 100%;
+      float: left;
+      padding: 10px 0;
+    }
+  }
+  @media (max-width: 1450px) {
+    section {
+      width: 50%;
+      float: left;
+      padding: 0;
+    }
+    section:first-of-type {
+      padding: 0;
+    }
+  }
+}

--- a/src/app/health-status/health-status.component.html
+++ b/src/app/health-status/health-status.component.html
@@ -1,8 +1,8 @@
 <div class="wrapper">
-  <section>
+  <section class="clearfix">
     <app-clinical-test-results *ngIf="featureToggling.status.clinicalResults"></app-clinical-test-results>
   </section>
-  <section>
+  <section class="clearfix">
     <app-lab-test-result *ngIf="featureToggling.status.labResults"></app-lab-test-result>
   </section>
 </div>

--- a/src/app/lab-test-result/lab-test-result.component.html
+++ b/src/app/lab-test-result/lab-test-result.component.html
@@ -21,7 +21,7 @@
     </td>
   </tr>
   <tr *ngIf="!dataservice.labResults || dataservice.labResults.length === 0">
-    <td colspan="3">
+    <td colspan="3" style="height: 200px;">
       <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
     </td>
   </tr>

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -171,11 +171,13 @@ export class DataService {
     this.currentPatientId = patientId;
     this.targetValues = [];
     this.targetValuesDataSource.data = this.targetValues;
+    console.log("DATA-174", JSON.stringify(this.targetValuesDataSource));
     this.activeMedications = emptyMediciationSummary;
     this.vitalSigns = emptyVitalSigns;
     this.vitalSignsDataSource.data = this.vitalSigns.tableData;
-
+    console.log("DATA-178", JSON.stringify(this.vitalSignsDataSource));
     this.activeMedicationsDataSource.data = this.activeMedications;
+    console.log("DATA-180", JSON.stringify(this.activeMedicationsDataSource));
     if ((!patientId || patientId.trim().length === 0)) {
       this.currentPatientId = dummyPatientId;
       this.currentCareplanId = dummyCareplanId;

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,3 +24,13 @@ body {
 .col-50 {
     width: 50%;
 }
+
+.clearfix {
+    overflow: auto;
+}
+
+.clearfix::after {
+    content: "";
+    clear: both;
+    display: table;
+}


### PR DESCRIPTION
- Release ("1.2.0")
- Attempt to fix IE 11 Table overlap bug on "Health Status" screen (unable to debug IE11 locally)
- More logging on "DATA" property assignments
- Better spinner handling