### PR TITLE
Feature/fix conditions recorded date

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ The file names and types must match exactly.  Also, you must include all json fi
 $ docker run -v {Full 'json/data' Directory Path}:/usr/share/nginx/html/assets/json/data -d -p 80:80 --rm mcccareplan/mccproviderapp
 
 #Changelog
+2021-08-16
+- Release ("1.2.3")
+- Changed the "firstRecorded" date in Active/Inactive diagnosis panels to use "firstRecordedAsText" due to timezone rendering issues offsetting rendered date by a day
+- Added loading spinners to Medications, Education, Counseling and Referrals
+
 2021-08-05
 - Release ("1.2.2")
 - Changed EGFR data service to correctly parse string value types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "providersmartapp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/active-diagnosis-panel/active-diagnosis-panel.component.html
+++ b/src/app/active-diagnosis-panel/active-diagnosis-panel.component.html
@@ -32,7 +32,7 @@
   </ng-container>
   <ng-container matColumnDef="firstRecorded">
     <th mat-header-cell *matHeaderCellDef mat-sort-header>Diagnosis First Recorded</th>
-    <td mat-cell *matCellDef="let condition">{{condition.firstRecorded | date: 'MM/dd/yyyy' }}</td>
+    <td mat-cell *matCellDef="let condition">{{condition.firstRecordedAsText | nullCheck}}</td>
   </ng-container>
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>

--- a/src/app/inactive-diagnosis-panel/inactive-diagnosis-panel.component.html
+++ b/src/app/inactive-diagnosis-panel/inactive-diagnosis-panel.component.html
@@ -33,7 +33,7 @@
   </ng-container>
   <ng-container matColumnDef="firstRecorded">
     <th mat-header-cell *matHeaderCellDef mat-sort-header>Diagnosis First Recorded</th>
-    <td mat-cell *matCellDef="let condition"> {{condition.firstRecorded | date: 'MM/dd/yyyy'}} </td>
+    <td mat-cell *matCellDef="let condition"> {{condition.firstRecordedAsText | nullCheck}} </td>
   </ng-container>
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>

--- a/src/app/maintenance-and-interventions/maintenance-and-interventions.component.html
+++ b/src/app/maintenance-and-interventions/maintenance-and-interventions.component.html
@@ -4,9 +4,19 @@
       <app-medication-panel></app-medication-panel>
     </td>
   </tr>
+  <tr *ngIf="featureToggling.maintenanceAndInterventions.medications && !getMedicationIsReady()">
+    <td colspan="3" style="height: 200px;">
+      <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+    </td>
+  </tr>
   <tr *ngIf="featureToggling.maintenanceAndInterventions.education && getEducationIsReady()">
     <td>
       <app-education-panel></app-education-panel>
+    </td>
+  </tr>
+  <tr *ngIf="featureToggling.maintenanceAndInterventions.education && !getEducationIsReady()">
+    <td colspan="3" style="height: 200px;">
+      <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
     </td>
   </tr>
   <tr *ngIf="featureToggling.maintenanceAndInterventions.counseling && getCounselingIsReady()">
@@ -14,9 +24,19 @@
       <app-counseling-panel></app-counseling-panel>
     </td>
   </tr>
+  <tr *ngIf="featureToggling.maintenanceAndInterventions.counseling && !getCounselingIsReady()">
+    <td colspan="3" style="height: 200px;">
+      <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+    </td>
+  </tr>
   <tr *ngIf="featureToggling.maintenanceAndInterventions.referrals && getReferralsIsReady()">
     <td>
       <app-referral-panel></app-referral-panel>
+    </td>
+  </tr>
+  <tr *ngIf="featureToggling.maintenanceAndInterventions.referrals && !getReferralsIsReady()">
+    <td colspan="3" style="height: 200px;">
+      <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
- Release ("1.2.3")
- Changed the "firstRecorded" date in Active/Inactive diagnosis panels to use "firstRecordedAsText" due to timezone rendering issues offsetting rendered date by a day
- Added loading spinners to Medications, Education, Counseling and Referrals